### PR TITLE
Elevated sudo required fro install commands

### DIFF
--- a/.ebextensions/01_deploy.config
+++ b/.ebextensions/01_deploy.config
@@ -26,7 +26,7 @@ container_commands:
     cwd: "/var/app/staging"
 
   03_build_node_assets:
-    command: npm run prod
+    command: "sudo npm run prod"
     cwd: "/var/app/staging"
 
   04_link_storage_folder:


### PR DESCRIPTION
composer install and npm install commands are failing on `PHP 7.4 running on 64bit Amazon Linux 2/3.0.1` due to lack of access rights. If they are sudo elevated , it works fine.