### PR TITLE
Amazon ami

### DIFF
--- a/.ebextensions/01_deploy.config
+++ b/.ebextensions/01_deploy.config
@@ -49,8 +49,8 @@ container_commands:
     leader_only: true
   04_01_fix_permissions:
     command: |
-      chmod -R 777 /var/app/current/storage/
-      chmod -R 777 /var/app/current/bootstrap/cache/
-      chown -R webapp:webapp /var/app/current/storage/
-      chown -R webapp:webapp /var/app/current/bootstrap/cache/
+      chmod -R 777 /var/app/ondeck/storage/
+      chmod -R 777 /var/app/ondeck/bootstrap/cache/
+      chown -R webapp:webapp /var/app/ondeck/storage/
+      chown -R webapp:webapp /var/app/ondeck/bootstrap/cache/
     cwd: "/var/app/ondeck"


### PR DESCRIPTION
chmod is throwing error as `/var/app/current` is yet not available while deployment is happening in 04_01_fix_permissions step.

If my understanding is correct, replacing path with `/var/app/ondeck` will retain the chmod permissions while it switches to current.