### PR TITLE
[fix] Main PHP process didn't use FASTCGI

### DIFF
--- a/.platform/hooks/postdeploy/create_cron_files.sh
+++ b/.platform/hooks/postdeploy/create_cron_files.sh
@@ -6,7 +6,7 @@
 # the php artisan schedule:run command
 
 echo "* * * * * root /usr/bin/php /var/app/current/artisan schedule:run 1>> /dev/null 2>&1" \
-    | sudo tee /etc/cron.d/artisan_scheduler
+  | sudo tee /etc/cron.d/artisan_scheduler
 
 # In some cases, Laravel logs a lot of data in the storage/logs/laravel.log and it sometimes
 # might turn out into massive files that will restrict the filesystem.
@@ -14,4 +14,4 @@ echo "* * * * * root /usr/bin/php /var/app/current/artisan schedule:run 1>> /dev
 # every now and often.
 
 # echo "0 0 * * */7 root rm -rf /var/app/current/storage/logs/laravel.log 1>> /dev/null 2>&1" \
-#     | sudo tee /etc/cron.d/log_deleter
+#   | sudo tee /etc/cron.d/log_deleter

--- a/.platform/nginx/conf.d/elasticbeanstalk/https.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/https.conf
@@ -5,5 +5,5 @@
 # for the NGINX Proxy service.
 
 # if ($http_x_forwarded_proto = 'http') {
-#     return 301 https://$host$request_uri;
+#   return 301 https://$host$request_uri;
 # }

--- a/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
@@ -11,6 +11,13 @@ add_header X-Frame-Options "SAMEORIGIN";
 add_header X-XSS-Protection "1; mode=block";
 add_header X-Content-Type-Options "nosniff";
 
+# Feel free to change the fastcgi buffers
+# in case you have issues with them.
+# They should be increased in case your payload
+# (HTTP responses) are big.
+# fastcgi_buffers 16 16k;
+# fastcgi_buffer_size 32k;
+
 index index.html index.htm index.php;
 
 charset utf-8;

--- a/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
@@ -23,3 +23,14 @@ location = /favicon.ico { access_log off; log_not_found off; }
 location = /robots.txt  { access_log off; log_not_found off; }
 
 error_page 404 /index.php;
+
+location ~ \.php$ {
+  fastcgi_pass php-fpm;
+  fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+
+  include fastcgi_params;
+}
+
+location ~ /\.(?!well-known).* {
+  deny all;
+}

--- a/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
@@ -24,7 +24,7 @@ index index.html index.htm index.php;
 charset utf-8;
 
 location / {
-    try_files $uri $uri/ /index.php?$query_string;
+  try_files $uri $uri/ /index.php?$query_string;
 }
 
 location = /favicon.ico { access_log off; log_not_found off; }
@@ -33,31 +33,31 @@ location = /robots.txt  { access_log off; log_not_found off; }
 error_page 404 /index.php;
 
 location ~ \.php$ {
-    fastcgi_pass php-fpm;
-    fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
-    fastcgi_index index.php;
+  fastcgi_pass php-fpm;
+  fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+  fastcgi_index index.php;
 
-    fastcgi_param  QUERY_STRING       $query_string;
-    fastcgi_param  REQUEST_METHOD     $request_method;
-    fastcgi_param  CONTENT_TYPE       $content_type;
-    fastcgi_param  CONTENT_LENGTH     $content_length;
-    fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
-    fastcgi_param  REQUEST_URI        $request_uri;
-    fastcgi_param  DOCUMENT_URI       $document_uri;
-    fastcgi_param  DOCUMENT_ROOT      $document_root;
-    fastcgi_param  SERVER_PROTOCOL    $server_protocol;
-    fastcgi_param  REQUEST_SCHEME     $scheme;
-    fastcgi_param  HTTPS              $https if_not_empty;
-    fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
-    fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
-    fastcgi_param  REMOTE_ADDR        $remote_addr;
-    fastcgi_param  REMOTE_PORT        $remote_port;
-    fastcgi_param  SERVER_ADDR        $server_addr;
-    fastcgi_param  SERVER_PORT        $server_port;
-    fastcgi_param  SERVER_NAME        $server_name;
-    fastcgi_param  REDIRECT_STATUS    200;
+  fastcgi_param  QUERY_STRING       $query_string;
+  fastcgi_param  REQUEST_METHOD     $request_method;
+  fastcgi_param  CONTENT_TYPE       $content_type;
+  fastcgi_param  CONTENT_LENGTH     $content_length;
+  fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+  fastcgi_param  REQUEST_URI        $request_uri;
+  fastcgi_param  DOCUMENT_URI       $document_uri;
+  fastcgi_param  DOCUMENT_ROOT      $document_root;
+  fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+  fastcgi_param  REQUEST_SCHEME     $scheme;
+  fastcgi_param  HTTPS              $https if_not_empty;
+  fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+  fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+  fastcgi_param  REMOTE_ADDR        $remote_addr;
+  fastcgi_param  REMOTE_PORT        $remote_port;
+  fastcgi_param  SERVER_ADDR        $server_addr;
+  fastcgi_param  SERVER_PORT        $server_port;
+  fastcgi_param  SERVER_NAME        $server_name;
+  fastcgi_param  REDIRECT_STATUS    200;
 }
 
 location ~ /\.(?!well-known).* {
-    deny all;
+  deny all;
 }

--- a/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
@@ -25,30 +25,30 @@ location = /robots.txt  { access_log off; log_not_found off; }
 error_page 404 /index.php;
 
 location ~ \.php$ {
-  fastcgi_pass php-fpm;
-  fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+    fastcgi_pass php-fpm;
+    fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
 
-  fastcgi_param  QUERY_STRING       $query_string;
-  fastcgi_param  REQUEST_METHOD     $request_method;
-  fastcgi_param  CONTENT_TYPE       $content_type;
-  fastcgi_param  CONTENT_LENGTH     $content_length;
-  fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
-  fastcgi_param  REQUEST_URI        $request_uri;
-  fastcgi_param  DOCUMENT_URI       $document_uri;
-  fastcgi_param  DOCUMENT_ROOT      $document_root;
-  fastcgi_param  SERVER_PROTOCOL    $server_protocol;
-  fastcgi_param  REQUEST_SCHEME     $scheme;
-  fastcgi_param  HTTPS              $https if_not_empty;
-  fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
-  fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
-  fastcgi_param  REMOTE_ADDR        $remote_addr;
-  fastcgi_param  REMOTE_PORT        $remote_port;
-  fastcgi_param  SERVER_ADDR        $server_addr;
-  fastcgi_param  SERVER_PORT        $server_port;
-  fastcgi_param  SERVER_NAME        $server_name;
-  fastcgi_param  REDIRECT_STATUS    200;
+    fastcgi_param  QUERY_STRING       $query_string;
+    fastcgi_param  REQUEST_METHOD     $request_method;
+    fastcgi_param  CONTENT_TYPE       $content_type;
+    fastcgi_param  CONTENT_LENGTH     $content_length;
+    fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+    fastcgi_param  REQUEST_URI        $request_uri;
+    fastcgi_param  DOCUMENT_URI       $document_uri;
+    fastcgi_param  DOCUMENT_ROOT      $document_root;
+    fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+    fastcgi_param  REQUEST_SCHEME     $scheme;
+    fastcgi_param  HTTPS              $https if_not_empty;
+    fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+    fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+    fastcgi_param  REMOTE_ADDR        $remote_addr;
+    fastcgi_param  REMOTE_PORT        $remote_port;
+    fastcgi_param  SERVER_ADDR        $server_addr;
+    fastcgi_param  SERVER_PORT        $server_port;
+    fastcgi_param  SERVER_NAME        $server_name;
+    fastcgi_param  REDIRECT_STATUS    200;
 }
 
 location ~ /\.(?!well-known).* {
-  deny all;
+    deny all;
 }

--- a/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
@@ -28,7 +28,25 @@ location ~ \.php$ {
   fastcgi_pass php-fpm;
   fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
 
-  include fastcgi_params;
+  fastcgi_param  QUERY_STRING       $query_string;
+  fastcgi_param  REQUEST_METHOD     $request_method;
+  fastcgi_param  CONTENT_TYPE       $content_type;
+  fastcgi_param  CONTENT_LENGTH     $content_length;
+  fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+  fastcgi_param  REQUEST_URI        $request_uri;
+  fastcgi_param  DOCUMENT_URI       $document_uri;
+  fastcgi_param  DOCUMENT_ROOT      $document_root;
+  fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+  fastcgi_param  REQUEST_SCHEME     $scheme;
+  fastcgi_param  HTTPS              $https if_not_empty;
+  fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+  fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+  fastcgi_param  REMOTE_ADDR        $remote_addr;
+  fastcgi_param  REMOTE_PORT        $remote_port;
+  fastcgi_param  SERVER_ADDR        $server_addr;
+  fastcgi_param  SERVER_PORT        $server_port;
+  fastcgi_param  SERVER_NAME        $server_name;
+  fastcgi_param  REDIRECT_STATUS    200;
 }
 
 location ~ /\.(?!well-known).* {

--- a/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
@@ -15,6 +15,7 @@ add_header X-Content-Type-Options "nosniff";
 # in case you have issues with them.
 # They should be increased in case your payload
 # (HTTP responses) are big.
+
 # fastcgi_buffers 16 16k;
 # fastcgi_buffer_size 32k;
 
@@ -34,6 +35,7 @@ error_page 404 /index.php;
 location ~ \.php$ {
     fastcgi_pass php-fpm;
     fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+    fastcgi_index index.php;
 
     fastcgi_param  QUERY_STRING       $query_string;
     fastcgi_param  REQUEST_METHOD     $request_method;


### PR DESCRIPTION
I have stumbled upon PHP-FPM related errors because the main process didn't get thru the right socket upstream. According to this: https://laravel.com/docs/7.x/deployment#nginx, there should be a `~ \.php$` location that tells the request to get thru the PHP-FPM socket.

If you check `/etc/nginx/conf.d/php-fpm.conf` on a EB-created instance, you would see a `php-fpm`-defined upstream already, so there is no need to set any custom-named process name.

Here it is the right definition, as the docs on upstreams in nginx says so: http://nginx.org/en/docs/http/ngx_http_upstream_module.html

I am still testing it on a separate environment to see how well it behaves under low and high-pressure conditions.