### PR TITLE
Add client_max_body_size and client_body_buffer_size

### DIFF
--- a/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
+++ b/.platform/nginx/conf.d/elasticbeanstalk/laravel.conf
@@ -11,6 +11,16 @@ add_header X-Frame-Options "SAMEORIGIN";
 add_header X-XSS-Protection "1; mode=block";
 add_header X-Content-Type-Options "nosniff";
 
+# Sets the maximum allowed size of the client request body.
+# If the size in a request exceeds the configured value, 
+# the 413 (Request Entity Too Large) error is returned to the client
+# http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+# client_max_body_size 32M;
+
+# Sets buffer size for reading client request body.
+# http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size
+# client_body_buffer_size 16k;
+
 # Feel free to change the fastcgi buffers
 # in case you have issues with them.
 # They should be increased in case your payload


### PR DESCRIPTION
Syntax:	client_body_buffer_size size;
Default:	client_body_buffer_size 8k|16k;
Context:	http, server, location

Sets buffer size for reading client request body. In case the request body is larger than the buffer, the whole body or only its part is written to a temporary file. By default, buffer size is equal to two memory pages. This is 8K on x86, other 32-bit platforms, and x86-64. It is usually 16K on other 64-bit platforms.

**Increase client_max_body_size to control upload allowed file size**
Syntax:	client_max_body_size size;
Default:	client_max_body_size 1m;
Context:	http, server, location
Sets the maximum allowed size of the client request body, specified in the “Content-Length” request header field. If the size in a request exceeds the configured value, the 413 (Request Entity Too Large) error is returned to the client. Please be aware that browsers cannot correctly display this error. Setting size to 0 disables checking of client request body size.