### PR TITLE
EB config file to stream laravel log to cloudwatch

### DIFF
--- a/.ebextensions/01_logs_streamtocloudwatch.config
+++ b/.ebextensions/01_logs_streamtocloudwatch.config
@@ -1,20 +1,14 @@
-## The following file installs and configures the AWS CloudWatch Logs agent to push logs to a Log
-## Group in CloudWatch Logs.
- 
-## The configuration below sets the logs to be pushed, the Log Group name to push the logs to and
-## the Log Stream name as the instance id. The following files are examples of logs that will be
-## streamed to CloudWatch Logs in near real time: 
-## /var/app/current/storage/logs/laravel.log
+# The following file installs and configures the AWS CloudWatch Logs agent
+# to push the /var/app/current/storage/logs/laravel.log file to a Log Group in CloudWatch Logs.
 
-## You can then access the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
-## the "Logs" link on the left. The Log Group name will follow this format:
-##
-## /aws/elasticbeanstalk/<environment name>/<full log name path>
+# You can then see the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
+# the "Logs" link on the left. The Log Group name will follow this format:
+# /aws/elasticbeanstalk/<environment name>/<full log name path>
 
-## Please note this configuration can be used additionally to the "Log Streaming" feature:
+## For more information about "Log Streaming" feature, see:
 ## http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
 
-## Example configuration file:
+## This file was templated based on the following example:
 ## https://github.com/awsdocs/elastic-beanstalk-samples/blob/master/configuration-files/aws-provided/instance-configuration/logs-streamtocloudwatch-linux.config
 
 # Usually, the option_settings with enabled Stream Logs should be uncommented if you are not using IaaC, like Chef or Terraform.

--- a/.ebextensions/01_logs_streamtocloudwatch.config
+++ b/.ebextensions/01_logs_streamtocloudwatch.config
@@ -65,7 +65,7 @@ packages:
 #       [/var/app/current/storage/logs]
 #       datetime_format = %Y-%m-%d %H:%M:%S
 #       log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/storage/logs"]]}`
-#       log_stream_name = logs
+#       log_stream_name = {instance_id}
 #       timestamp_format = '[%Y-%m-%d %H:%M:%S]'
 #       file = /var/app/current/storage/logs/laravel.log
 #       buffer_duration = 5000

--- a/.ebextensions/01_logs_streamtocloudwatch.config
+++ b/.ebextensions/01_logs_streamtocloudwatch.config
@@ -1,0 +1,76 @@
+###################################################################################################
+#### The following file installs and configures the AWS CloudWatch Logs agent to push logs to a Log
+#### Group in CloudWatch Logs.
+#### 
+#### The configuration below sets the logs to be pushed, the Log Group name to push the logs to and
+#### the Log Stream name as the instance id. The following files are examples of logs that will be
+#### streamed to CloudWatch Logs in near real time:
+#### 
+#### /var/app/current/storage/logs/laravel.log
+#### 
+#### You can then access the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
+#### the "Logs" link on the left. The Log Group name will follow this format:
+####
+#### /aws/elasticbeanstalk/<environment name>/<full log name path>
+####
+#### Please note this configuration can be used additionally to the "Log Streaming" feature:
+#### http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
+####
+#### Example configuration file:
+#### https://github.com/awsdocs/elastic-beanstalk-samples/blob/master/configuration-files/aws-provided/instance-configuration/logs-streamtocloudwatch-linux.config
+###################################################################################################
+
+option_settings:
+  - namespace: aws:elasticbeanstalk:cloudwatch:logs
+    option_name: StreamLogs
+    value: true
+  - namespace: aws:elasticbeanstalk:cloudwatch:logs
+    option_name: DeleteOnTerminate
+    value: false
+  - namespace: aws:elasticbeanstalk:cloudwatch:logs
+    option_name: RetentionInDays
+    value: 7
+
+packages:
+  yum:
+    awslogs: []
+
+files:
+  "/etc/awslogs/awscli.conf" :
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      [plugins]
+      cwlogs = cwlogs
+      [default]
+      region = `{"Ref":"AWS::Region"}`
+
+  "/etc/awslogs/awslogs.conf" :
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      [general]
+      state_file = /var/lib/awslogs/agent-state
+
+  "/etc/awslogs/config/logs.conf" :
+    mode: "000600"
+    owner: root
+    group: root
+    content: |
+      [/var/app/current/storage/logs]
+      datetime_format = %Y-%m-%d %H:%M:%S
+      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/storage/logs"]]}`
+      log_stream_name = logs
+      timestamp_format = '[%Y-%m-%d %H:%M:%S]'
+      file = /var/app/current/storage/logs/laravel.log
+      buffer_duration = 5000
+      use_gzip_http_content_encoding = true
+      multi_line_start_pattern = {datetime_format}
+
+commands:    
+  "01":
+    command: systemctl enable awslogsd.service
+  "02":
+    command: systemctl restart awslogsd

--- a/.ebextensions/01_logs_streamtocloudwatch.config
+++ b/.ebextensions/01_logs_streamtocloudwatch.config
@@ -1,76 +1,79 @@
-###################################################################################################
-#### The following file installs and configures the AWS CloudWatch Logs agent to push logs to a Log
-#### Group in CloudWatch Logs.
-#### 
-#### The configuration below sets the logs to be pushed, the Log Group name to push the logs to and
-#### the Log Stream name as the instance id. The following files are examples of logs that will be
-#### streamed to CloudWatch Logs in near real time:
-#### 
-#### /var/app/current/storage/logs/laravel.log
-#### 
-#### You can then access the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
-#### the "Logs" link on the left. The Log Group name will follow this format:
-####
-#### /aws/elasticbeanstalk/<environment name>/<full log name path>
-####
-#### Please note this configuration can be used additionally to the "Log Streaming" feature:
-#### http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
-####
-#### Example configuration file:
-#### https://github.com/awsdocs/elastic-beanstalk-samples/blob/master/configuration-files/aws-provided/instance-configuration/logs-streamtocloudwatch-linux.config
-###################################################################################################
+## The following file installs and configures the AWS CloudWatch Logs agent to push logs to a Log
+## Group in CloudWatch Logs.
+ 
+## The configuration below sets the logs to be pushed, the Log Group name to push the logs to and
+## the Log Stream name as the instance id. The following files are examples of logs that will be
+## streamed to CloudWatch Logs in near real time: 
+## /var/app/current/storage/logs/laravel.log
 
-option_settings:
-  - namespace: aws:elasticbeanstalk:cloudwatch:logs
-    option_name: StreamLogs
-    value: true
-  - namespace: aws:elasticbeanstalk:cloudwatch:logs
-    option_name: DeleteOnTerminate
-    value: false
-  - namespace: aws:elasticbeanstalk:cloudwatch:logs
-    option_name: RetentionInDays
-    value: 7
+## You can then access the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
+## the "Logs" link on the left. The Log Group name will follow this format:
+##
+## /aws/elasticbeanstalk/<environment name>/<full log name path>
+
+## Please note this configuration can be used additionally to the "Log Streaming" feature:
+## http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
+
+## Example configuration file:
+## https://github.com/awsdocs/elastic-beanstalk-samples/blob/master/configuration-files/aws-provided/instance-configuration/logs-streamtocloudwatch-linux.config
+
+# Usually, the option_settings with enabled Stream Logs should be uncommented if you are not using IaaC, like Chef or Terraform.
+# If you created the environment manually, uncomment the following lines and set the amount of retention in days.
+
+# option_settings:
+#   - namespace: aws:elasticbeanstalk:cloudwatch:logs
+#     option_name: StreamLogs
+#     value: true
+#   - namespace: aws:elasticbeanstalk:cloudwatch:logs
+#     option_name: DeleteOnTerminate
+#     value: false
+#   - namespace: aws:elasticbeanstalk:cloudwatch:logs
+#     option_name: RetentionInDays
+#     value: 7
 
 packages:
   yum:
     awslogs: []
 
-files:
-  "/etc/awslogs/awscli.conf" :
-    mode: "000600"
-    owner: root
-    group: root
-    content: |
-      [plugins]
-      cwlogs = cwlogs
-      [default]
-      region = `{"Ref":"AWS::Region"}`
+# To enable the AWS logs configuration, uncomment the following lines. This will configure your EC2 instance
+# to install and configure the AWS Cloudwatch Logs agent to stream your storage/logs/laravel.log file.
 
-  "/etc/awslogs/awslogs.conf" :
-    mode: "000600"
-    owner: root
-    group: root
-    content: |
-      [general]
-      state_file = /var/lib/awslogs/agent-state
+# files:
+#   "/etc/awslogs/awscli.conf" :
+#     mode: "000600"
+#     owner: root
+#     group: root
+#     content: |
+#       [plugins]
+#       cwlogs = cwlogs
+#       [default]
+#       region = `{"Ref":"AWS::Region"}`
+# 
+#   "/etc/awslogs/awslogs.conf" :
+#     mode: "000600"
+#     owner: root
+#     group: root
+#     content: |
+#       [general]
+#       state_file = /var/lib/awslogs/agent-state
+# 
+#   "/etc/awslogs/config/logs.conf" :
+#     mode: "000600"
+#     owner: root
+#     group: root
+#     content: |
+#       [/var/app/current/storage/logs]
+#       datetime_format = %Y-%m-%d %H:%M:%S
+#       log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/storage/logs"]]}`
+#       log_stream_name = logs
+#       timestamp_format = '[%Y-%m-%d %H:%M:%S]'
+#       file = /var/app/current/storage/logs/laravel.log
+#       buffer_duration = 5000
+#       use_gzip_http_content_encoding = true
+#       multi_line_start_pattern = {datetime_format}
 
-  "/etc/awslogs/config/logs.conf" :
-    mode: "000600"
-    owner: root
-    group: root
-    content: |
-      [/var/app/current/storage/logs]
-      datetime_format = %Y-%m-%d %H:%M:%S
-      log_group_name = `{"Fn::Join":["/", ["/aws/elasticbeanstalk", { "Ref":"AWSEBEnvironmentName" }, "var/app/current/storage/logs"]]}`
-      log_stream_name = logs
-      timestamp_format = '[%Y-%m-%d %H:%M:%S]'
-      file = /var/app/current/storage/logs/laravel.log
-      buffer_duration = 5000
-      use_gzip_http_content_encoding = true
-      multi_line_start_pattern = {datetime_format}
-
-commands:    
-  "01":
-    command: systemctl enable awslogsd.service
-  "02":
-    command: systemctl restart awslogsd
+# commands:    
+#   "01_enable_aws_log_daemon":
+#     command: systemctl enable awslogsd.service
+#   "02_restart_aws_log_daemon":
+#     command: systemctl restart awslogsd


### PR DESCRIPTION
Just migrated to Amazon linux 2 using this repo; I saw there wasnt a config file to stream laravel.log to cloudwatch. Probably some people would find this usefull.