### PR TITLE
Run cron jobs as webapp instead of root

### DIFF
--- a/.platform/hooks/postdeploy/create_cron_files.sh
+++ b/.platform/hooks/postdeploy/create_cron_files.sh
@@ -5,7 +5,7 @@
 # After the deployment finishes, set up a Crontab for
 # the php artisan schedule:run command
 
-echo "* * * * * root /usr/bin/php /var/app/current/artisan schedule:run 1>> /dev/null 2>&1" \
+echo "* * * * * webapp /usr/bin/php /var/app/current/artisan schedule:run 1>> /dev/null 2>&1" \
   | sudo tee /etc/cron.d/artisan_scheduler
 
 # In some cases, Laravel logs a lot of data in the storage/logs/laravel.log and it sometimes


### PR DESCRIPTION
Running the Laravel scheduler as `root` will create log files owned by the root user which can not be accessed by the web application.
This creates permission issues when trying to append logs to existing log files.

So I believe the cron job needs to be run by the `webapp` user just the like the web application is. That's how I fixed my issue.