### PR TITLE
[feature] Added new version of Cloudwatch agent log streaming that is recommended for Amazon Linux 2

### DIFF
--- a/.ebextensions/02_logs_cloudwatch_imds2.config
+++ b/.ebextensions/02_logs_cloudwatch_imds2.config
@@ -11,7 +11,7 @@
 # /aws/elasticbeanstalk/<environment name>/<full log name path>
 
 ## For more information about "Log Streaming" feature, see:
-## http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
+## https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/QuickStartEC2Instance.html
 
 # Usually, the option_settings with enabled Stream Logs should be uncommented if you are not using IaaC, like Chef or Terraform.
 # If you created the environment manually, uncomment the following lines and set the amount of retention in days.

--- a/.ebextensions/02_logs_cloudwatch_imds2.config
+++ b/.ebextensions/02_logs_cloudwatch_imds2.config
@@ -1,0 +1,56 @@
+# The following file configures a new version of cloudwatch logs agent that uses IMDSv2 instead of IMDSv1
+# to push the /var/app/current/storage/logs/*.log files to a Log Group in CloudWatch Logs.
+
+# This version of cloudwatch logs agent is installed automatically on AMI2 instances
+
+# The old version of cloudwatch doesn't support Metadata Service Version 2 (IMDSv2) and it's recommended to use a new one
+# Link to reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/QuickStartEC2Instance.html
+
+# You can then see the CloudWatch Logs by accessing the AWS CloudWatch Console and clicking
+# the "Logs" link on the left. The Log Group name will follow this format:
+# /aws/elasticbeanstalk/<environment name>/<full log name path>
+
+## For more information about "Log Streaming" feature, see:
+## http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/AWSHowTo.cloudwatchlogs.html
+
+# Usually, the option_settings with enabled Stream Logs should be uncommented if you are not using IaaC, like Chef or Terraform.
+# If you created the environment manually, uncomment the following lines and set the amount of retention in days.
+
+# Before uncommenting this, please update <environment name> to match yours, or name it as you wish
+
+# option_settings:
+#   - namespace: aws:elasticbeanstalk:cloudwatch:logs
+#     option_name: StreamLogs
+#     value: true
+#   - namespace: aws:elasticbeanstalk:cloudwatch:logs
+#     option_name: DeleteOnTerminate
+#     value: false
+#   - namespace: aws:elasticbeanstalk:cloudwatch:logs
+#     option_name: RetentionInDays
+#     value: 7
+
+#files:
+#   "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/laravel_logs.json" :
+#     mode: "000644"
+#     owner: root
+#     group: root
+#     content: |
+#         {
+#             "logs": {
+#                 "logs_collected": {
+#                     "files": {
+#                         "collect_list": [
+#                             {
+#                                 "file_path": "/var/app/current/storage/logs/*.log",
+#                                 "log_group_name": "/aws/elasticbeanstalk/<environment name>/var/app/current/storage/logs/",
+#                                 "log_stream_name": "{instance_id}"
+#                             }
+#                         ]
+#                     }
+#                 }
+#             }
+#         }
+
+#container_commands:
+#  start_cloudwatch_agent:
+#    command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/laravel_logs.json

--- a/.ebextensions/02_logs_cloudwatch_imds2.config
+++ b/.ebextensions/02_logs_cloudwatch_imds2.config
@@ -1,7 +1,7 @@
 # The following file configures a new version of cloudwatch logs agent that uses IMDSv2 instead of IMDSv1
 # to push the /var/app/current/storage/logs/*.log files to a Log Group in CloudWatch Logs.
 
-# This version of cloudwatch logs agent is installed automatically on AMI2 instances
+# This version of CloudWatch Logs agent is installed automatically on Amazon Linux 2 instances.
 
 # The old version of cloudwatch doesn't support Metadata Service Version 2 (IMDSv2) and it's recommended to use a new one
 # Link to reference: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/QuickStartEC2Instance.html
@@ -10,8 +10,8 @@
 # the "Logs" link on the left. The Log Group name will follow this format:
 # /aws/elasticbeanstalk/<environment name>/<full log name path>
 
-## For more information about "Log Streaming" feature, see:
-## https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/QuickStartEC2Instance.html
+# For more information about "Log Streaming" feature, see:
+# https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/QuickStartEC2Instance.html
 
 # Usually, the option_settings with enabled Stream Logs should be uncommented if you are not using IaaC, like Chef or Terraform.
 # If you created the environment manually, uncomment the following lines and set the amount of retention in days.
@@ -29,7 +29,7 @@
 #     option_name: RetentionInDays
 #     value: 7
 
-#files:
+# files:
 #   "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/laravel_logs.json" :
 #     mode: "000644"
 #     owner: root
@@ -51,6 +51,6 @@
 #             }
 #         }
 
-#container_commands:
-#  start_cloudwatch_agent:
-#    command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/laravel_logs.json
+# container_commands:
+#   start_cloudwatch_agent:
+#     command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/laravel_logs.json


### PR DESCRIPTION
Newer cloudwatch agent that comes preinstalled on Amazon Linux 2 and utilizes the IMDSv2 instead of v1

Docs: (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/QuickStartEC2Instance.html)