### PR TITLE
Comment fix: Replaced AWSElasticBeanstalkFullAccess

### DIFF
--- a/.ebextensions/00_copy_env_file.config
+++ b/.ebextensions/00_copy_env_file.config
@@ -2,7 +2,7 @@
 # when you created your first Elastic Beanstalk environment.
 
 # Make sure that the IAM Role for the EC2 Instance set in the Elastic Beanstalk configuration
-# has attached the `AWSElasticBeanstalkFullAccess` policy.
+# has attached the `AdministratorAccess-AWSElasticBeanstalk` policy.
 
 Resources:
   AWSEBAutoScalingGroup:


### PR DESCRIPTION
AWSElasticBeanstalkFullAccess was a managed IAM policy by AWS. They are now transitioning towards a new policy which is called AdministratorAccess-AWSElasticBeanstalk. Its not completely the same policy but new environments are created with this policy attached.

https://stackoverflow.com/questions/67485957/awselasticbeanstalkfullaccess-provides-full-access-equivalent/67498124#67498124