### PR TITLE
Fix: cloudwatch agent execution failed

### DIFF
--- a/.ebextensions/02_logs_cloudwatch_imds2.config
+++ b/.ebextensions/02_logs_cloudwatch_imds2.config
@@ -51,6 +51,6 @@
 #             }
 #         }
 
-# container_commands:
+# commands:
 #   start_cloudwatch_agent:
 #     command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/laravel_logs.json


### PR DESCRIPTION
Command execution wasn't processed at correct time so it couldn't fetch the laravel_logs.json settings to execute the command
Fix issues: #77, #74 
