### PR TITLE
Fix: cloudwatch imds v2 agent execution failed with hooks

### DIFF
--- a/.ebextensions/02_logs_cloudwatch_imds2.config
+++ b/.ebextensions/02_logs_cloudwatch_imds2.config
@@ -16,7 +16,8 @@
 # Usually, the option_settings with enabled Stream Logs should be uncommented if you are not using IaaC, like Chef or Terraform.
 # If you created the environment manually, uncomment the following lines and set the amount of retention in days.
 
-# Before uncommenting this, please update <environment name> to match yours, or name it as you wish
+# Before uncommenting this, please update <environment name> to match yours, or name it as you wish.
+# Also don't forget to uncomment as well .platform/hooks/postdeploy/logs_cloudwatch_imds2.sh
 
 # option_settings:
 #  - namespace: aws:elasticbeanstalk:cloudwatch:logs

--- a/.ebextensions/02_logs_cloudwatch_imds2.config
+++ b/.ebextensions/02_logs_cloudwatch_imds2.config
@@ -51,6 +51,6 @@
 #             }
 #         }
 
-# container_commands:
+# commands:
 #   start_cloudwatch_agent:
 #     command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/laravel_logs.json

--- a/.ebextensions/02_logs_cloudwatch_imds2.config
+++ b/.ebextensions/02_logs_cloudwatch_imds2.config
@@ -19,38 +19,12 @@
 # Before uncommenting this, please update <environment name> to match yours, or name it as you wish
 
 # option_settings:
-#   - namespace: aws:elasticbeanstalk:cloudwatch:logs
-#     option_name: StreamLogs
-#     value: true
-#   - namespace: aws:elasticbeanstalk:cloudwatch:logs
-#     option_name: DeleteOnTerminate
-#     value: false
-#   - namespace: aws:elasticbeanstalk:cloudwatch:logs
-#     option_name: RetentionInDays
-#     value: 7
-
-# files:
-#   "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/laravel_logs.json" :
-#     mode: "000644"
-#     owner: root
-#     group: root
-#     content: |
-#         {
-#             "logs": {
-#                 "logs_collected": {
-#                     "files": {
-#                         "collect_list": [
-#                             {
-#                                 "file_path": "/var/app/current/storage/logs/*.log",
-#                                 "log_group_name": "/aws/elasticbeanstalk/<environment name>/var/app/current/storage/logs/",
-#                                 "log_stream_name": "{instance_id}"
-#                             }
-#                         ]
-#                     }
-#                 }
-#             }
-#         }
-
-# commands:
-#   start_cloudwatch_agent:
-#     command: /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/laravel_logs.json
+#  - namespace: aws:elasticbeanstalk:cloudwatch:logs
+#    option_name: StreamLogs
+#    value: true
+#  - namespace: aws:elasticbeanstalk:cloudwatch:logs
+#    option_name: DeleteOnTerminate
+#    value: false
+#  - namespace: aws:elasticbeanstalk:cloudwatch:logs
+#    option_name: RetentionInDays
+#    value: 7

--- a/.platform/hooks/postdeploy/logs_cloudwatch_imds2.sh
+++ b/.platform/hooks/postdeploy/logs_cloudwatch_imds2.sh
@@ -1,3 +1,4 @@
+# Before uncommenting this please don't forget to also uncomment .ebextensions/02_logs_cloudwatch_imds2.config
 #!/bin/bash
 
 # echo '{

--- a/.platform/hooks/postdeploy/logs_cloudwatch_imds2.sh
+++ b/.platform/hooks/postdeploy/logs_cloudwatch_imds2.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# echo '{
+#         "logs": {
+#             "logs_collected": {
+#                 "files": {
+#                     "collect_list": [
+#                         {
+#                             "file_path": "/var/app/current/storage/logs/*.log",
+#                             "log_group_name": "/aws/elasticbeanstalk/<you-environment-name>/var/app/current/storage/logs/",
+#                             "log_stream_name": "{instance_id}"
+#                         }
+#                     ]
+#                 }
+#             }
+#         }
+#     }' > "/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/mycustomlogs.json"
+# /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config
+# /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a stop
+# /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a start


### PR DESCRIPTION
Command execution wasn't processed at correct time so it couldn't fetch the laravel_logs.json settings to execute the command
Fix issues: #77, #74 